### PR TITLE
Deploy CI to have dev dependencies for lint and test but not in zip

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -117,7 +117,7 @@ jobs:
 
       - name: Build
         working-directory: src
-        run: npm ci --production --prefer-offline
+        run: npm ci --prefer-offline
 
       - name: Lint
         working-directory: src
@@ -126,6 +126,11 @@ jobs:
       - name: Test
         working-directory: src
         run: npm test
+
+        # We only want the production dependencies in the zip file
+      - name: Prune
+        working-directory: src
+        run: npm prune --production
 
       - name: Package
         working-directory: src


### PR DESCRIPTION
Fixes [deploy failure](https://github.com/byu-oit/hw-lambda-api/actions/runs/950292950)